### PR TITLE
upgrade object-path to 0.11.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "netlify-cms": "^2.3.2",
     "netlify-cms-widget-color": "^3.0.1",
     "node-sass": "^4.13.1",
+    "object-path": "^0.11.5",
     "parcel-bundler": "^1.9.4",
     "prop-types": "^15.6.0",
     "react": "^16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8200,7 +8200,7 @@ object-keys@^1.0.12, object-keys@^1.0.6:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
-object-path@^0.11.2:
+object-path@^0.11.2, object-path@^0.11.5:
   version "0.11.5"
   resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.5.tgz#d4e3cf19601a5140a55a16ad712019a9c50b577a"
   integrity sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg==


### PR DESCRIPTION
dependabot didn't do so well it seems
https://github.com/dancormier/malloriepotaznick.com/pull/38